### PR TITLE
Create Endpoint for a simple attendance report

### DIFF
--- a/app/controllers/api/v1/attendance_controller.rb
+++ b/app/controllers/api/v1/attendance_controller.rb
@@ -1,0 +1,9 @@
+class Api::V1::AttendanceController < ApplicationController 
+    def index 
+        channel_id = params[:channel_id]
+        timestamp = params[:timestamp]
+        attendance_start_time = (Time.at(timestamp.to_f/1000000).end_of_hour + 60)
+        student_responses = SlackFacade.replies_from_message_v1(channel_id,timestamp)
+        render json: AttendanceSerializer.simple_report(student_responses, attendance_start_time)
+    end 
+end 

--- a/app/facades/slack_facade.rb
+++ b/app/facades/slack_facade.rb
@@ -30,6 +30,22 @@ class SlackFacade
             ChannelMember.new(slack_user_id, student_data)
         end 
     end 
+
+    def self.replies_from_message_v1(channel_id,timestamp)
+        message_start_time =  timestamp.to_f/1000000
+        conversation_data = SlackService.conversation_data(channel_id,message_start_time)
+        replies = conversation_data[:messages][1..-1]
+        students_and_answer_time = {}
+        replies.each do |reply|
+            time = Time.at(reply[:ts].to_f)
+            if students_and_answer_time[reply[:user]].nil?
+                students_and_answer_time[reply[:user]] = time
+            end 
+        end 
+        students_and_answer_time.map do |student,reply_timestamp|
+            SimpleStudentReport.new(student, reply_timestamp, message_start_time)
+        end
+    end 
 end 
 
 

--- a/app/poros/simple_student_report.rb
+++ b/app/poros/simple_student_report.rb
@@ -1,0 +1,27 @@
+class SimpleStudentReport 
+    attr_reader :timestamp, :slack_id
+
+    def initialize(user_id,reply_timestamp,message_send_time)
+        @timestamp = reply_timestamp
+        @message_send_time = message_send_time
+        @slack_id = user_id
+    end 
+
+    def attendance_start_time
+       @start_time ||= (Time.at(@message_send_time.to_f).end_of_hour + 360)
+    end 
+
+    def status 
+        return "present" if respond_before_5_after?
+        return "tardy" if respond_between_5_and_30?
+        return "absent" 
+    end 
+
+    def respond_before_5_after?
+        (attendance_start_time - @timestamp) > 0
+    end 
+
+    def respond_between_5_and_30?
+        0 > (attendance_start_time - @timestamp) && (attendance_start_time - @timestamp) > -1500
+    end 
+end 

--- a/app/serializers/attendance_serializer.rb
+++ b/app/serializers/attendance_serializer.rb
@@ -16,4 +16,18 @@ class AttendanceSerializer
             end 
         }
     end 
+
+    def self.simple_report(student_report, attendance_start_time)
+        {
+            total_replies: student_report.count,
+            attendance_start_time: attendance_start_time,
+            data: student_report.map do |student_info|
+                {
+                    slack_id: student_info.slack_id,
+                    status: student_info.status,
+                    reply_timestamp: student_info.timestamp
+                }
+            end 
+        }
+    end 
 end 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,5 +9,8 @@ Rails.application.routes.draw do
       resources :attendance, only: :index
       resources :channel_members, only: :index
     end 
+    namespace :v1 do 
+      resources :attendance, only: :index
+    end 
   end 
 end


### PR DESCRIPTION
This PR adds a new endpoint for getting replies from a slack thread. The purpose of this new endpoint is to use it within the Present app. The previous, v0 endpoint, should only be used for the Slack Attendance FE app. 